### PR TITLE
Fix #2: Auto-merge and pull for trusted contributor PRs

### DIFF
--- a/src/scheduler/worktree.ts
+++ b/src/scheduler/worktree.ts
@@ -219,6 +219,38 @@ export async function createPR(
   return { number: result.number, url: result.url };
 }
 
+// ─── Post-agent merge & sync ──────────────────────────────────────────────
+
+/**
+ * Squash-merge a pull request via gh CLI.
+ * Returns true if the merge succeeded, false otherwise (non-fatal).
+ */
+export async function mergePR(
+  worktreePath: string,
+  prNumber: number
+): Promise<boolean> {
+  try {
+    await gh(
+      ['pr', 'merge', String(prNumber), '--squash', '--delete-branch'],
+      worktreePath
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pull latest changes into the main repo from origin.
+ * Used after merging a PR so the local main branch stays in sync.
+ */
+export async function pullMain(
+  projectPath: string,
+  branch: string
+): Promise<void> {
+  await git(['pull', 'origin', branch], projectPath);
+}
+
 // ─── Post-agent issue comment support ─────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Fixes #2

Automated fix for: Auto-merge and pull for trusted contributor PRs in dispatch workflow.

## Changes
- `src/commands/dispatch-worker.ts` — Added auto-merge support for trusted contributor PRs
- `src/scheduler/scheduler.ts` — Added trusted contributor PR handling in scheduler
- `src/scheduler/worktree.ts` — Extended worktree operations for auto-merge flow

## Test plan
- [ ] Review auto-merge logic for trusted contributors
- [ ] Verify dispatch workflow handles the new PR flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)