### PR TITLE
Fix #13: Change credential scope default from allow to deny

### DIFF
--- a/credential-scopes.example.json
+++ b/credential-scopes.example.json
@@ -1,0 +1,10 @@
+{
+  "defaultPolicy": "deny",
+  "rules": {
+    "email": ["smtp_password", "imap_password"],
+    "calendar": ["oauth_token"],
+    "tana": ["tana_api_token"],
+    "github_issues": ["github_token"],
+    "agent_dispatch": ["*"]
+  }
+}

--- a/src/credential/scope.ts
+++ b/src/credential/scope.ts
@@ -8,7 +8,7 @@ const CONFIG_PATH = join(homedir(), '.pai', 'credential-scopes.json');
 
 /**
  * Load credential scope config from ~/.pai/credential-scopes.json.
- * Returns default allow-all config if file doesn't exist.
+ * Returns default deny-all config if file doesn't exist.
  */
 export function loadScopeConfig(path?: string): CredentialScopeConfig {
   const configPath = path ?? CONFIG_PATH;
@@ -21,7 +21,7 @@ export function loadScopeConfig(path?: string): CredentialScopeConfig {
     const raw = readFileSync(configPath, 'utf-8');
     const parsed = JSON.parse(raw);
     return {
-      defaultPolicy: parsed.defaultPolicy ?? 'allow',
+      defaultPolicy: parsed.defaultPolicy ?? 'deny',
       rules: parsed.rules ?? {},
     };
   } catch {

--- a/src/credential/types.ts
+++ b/src/credential/types.ts
@@ -14,6 +14,6 @@ export interface CredentialScopeConfig {
 }
 
 export const DEFAULT_SCOPE_CONFIG: CredentialScopeConfig = {
-  defaultPolicy: 'allow',
+  defaultPolicy: 'deny',
   rules: {},
 };

--- a/test/credential.test.ts
+++ b/test/credential.test.ts
@@ -91,7 +91,7 @@ describe('credential scope config', () => {
 
   test('returns default config when file does not exist', () => {
     const config = loadScopeConfig(join(tmpDir, 'nonexistent.json'));
-    expect(config.defaultPolicy).toBe('allow');
+    expect(config.defaultPolicy).toBe('deny');
     expect(config.rules).toEqual({});
   });
 
@@ -116,7 +116,7 @@ describe('credential scope config', () => {
     writeFileSync(configPath, 'not valid json {{{');
 
     const config = loadScopeConfig(configPath);
-    expect(config.defaultPolicy).toBe('allow');
+    expect(config.defaultPolicy).toBe('deny');
   });
 });
 


### PR DESCRIPTION
## Summary
- Flips `DEFAULT_SCOPE_CONFIG.defaultPolicy` from `'allow'` to `'deny'` in `src/credential/types.ts`
- Updates `loadScopeConfig()` fallback from `'allow'` to `'deny'` when config file is missing or has no `defaultPolicy` field
- Updates tests to assert the new deny-by-default behavior
- Adds `credential-scopes.example.json` documenting the migration pattern

## Test plan
- [x] All 13 credential tests pass with updated assertions
- [x] Full test suite passes (362 tests, 0 failures)
- [ ] Verify existing deployments have `~/.pai/credential-scopes.json` with explicit allow rules before upgrading

🤖 Generated with [Claude Code](https://claude.com/claude-code)