### PR TITLE
Fix #16: Issue #16: Create recovery work item when PR merge fails on trusted path

### DIFF
--- a/src/commands/dispatch-worker.ts
+++ b/src/commands/dispatch-worker.ts
@@ -6,6 +6,7 @@ import {
   getCurrentBranch,
   createWorktree,
   removeWorktree,
+  resolveWorktreePath,
   commitAll,
   pushBranch,
   createPR,
@@ -16,6 +17,7 @@ import {
 } from '../scheduler/worktree.ts';
 import { parseSpecFlowMeta } from '../scheduler/specflow-types.ts';
 import { runSpecFlowPhase } from '../scheduler/specflow-runner.ts';
+import { parseMergeFixMeta, createMergeFixWorkItem, runMergeFix } from '../scheduler/merge-fix.ts';
 import { getTanaAccessor } from '../evaluators/tana-accessor.ts';
 
 /**
@@ -306,6 +308,29 @@ export function registerDispatchWorkerCommand(
         return;
       }
 
+      // Determine if this is a merge-fix recovery work item
+      const mfMeta = parseMergeFixMeta(item.metadata);
+      if (mfMeta && project) {
+        const mfWorktreePath = resolveWorktreePath(project.local_path, mfMeta.branch, mfMeta.project_id);
+        try {
+          await runMergeFix(bb, item, mfMeta, project, sessionId, launcher, timeoutMs);
+          bb.completeWorkItem(itemId, sessionId);
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          try { bb.releaseWorkItem(itemId, sessionId); } catch { /* best effort */ }
+          bb.appendEvent({
+            actorId: sessionId,
+            targetId: itemId,
+            summary: `Merge-fix failed for PR #${mfMeta.pr_number}: ${msg}`,
+            metadata: { error: msg },
+          });
+        } finally {
+          try { await removeWorktree(project.local_path, mfWorktreePath); } catch { /* best effort */ }
+          try { bb.deregisterAgent(sessionId); } catch { /* best effort */ }
+        }
+        return;
+      }
+
       // Determine if this is a GitHub work item
       const ghMeta = parseGithubMeta(item.metadata);
       let workDir = resolvedWorkDir;
@@ -453,20 +478,44 @@ export function registerDispatchWorkerCommand(
                         });
                       }
                     } else {
+                      // Create recovery work item for merge failure
+                      const mergeFixId = createMergeFixWorkItem(bb, {
+                        originalItemId: itemId,
+                        prNumber: pr.number,
+                        prUrl: pr.url,
+                        branch: branch!,
+                        mainBranch: mainBranch!,
+                        issueNumber: ghMeta.issueNumber,
+                        projectId: item.project_id!,
+                        originalTitle: item.title,
+                        sessionId,
+                      });
                       bb.appendEvent({
                         actorId: sessionId,
                         targetId: itemId,
-                        summary: `Auto-merge failed for PR #${pr.number} — left open for manual review`,
-                        metadata: { prNumber: pr.number, autoMerge: false },
+                        summary: `Auto-merge failed for PR #${pr.number} — created recovery item ${mergeFixId}`,
+                        metadata: { prNumber: pr.number, autoMerge: false, mergeFixItemId: mergeFixId },
                       });
                     }
                   } catch (mergeErr: unknown) {
                     const mergeMsg = mergeErr instanceof Error ? mergeErr.message : String(mergeErr);
+                    // Create recovery work item for merge error
+                    const mergeFixId = createMergeFixWorkItem(bb, {
+                      originalItemId: itemId,
+                      prNumber: pr.number,
+                      prUrl: pr.url,
+                      branch: branch!,
+                      mainBranch: mainBranch!,
+                      issueNumber: ghMeta.issueNumber,
+                      projectId: item.project_id!,
+                      originalTitle: item.title,
+                      sessionId,
+                    });
                     bb.appendEvent({
                       actorId: sessionId,
                       targetId: itemId,
-                      summary: `Auto-merge error for PR #${pr.number} (non-fatal): ${mergeMsg}`,
-                      metadata: { prNumber: pr.number, error: mergeMsg },
+                      summary: `Auto-merge error for PR #${pr.number}: ${mergeMsg} — created recovery item ${mergeFixId}`,
+                      metadata: { prNumber: pr.number, error: mergeMsg, mergeFixItemId: mergeFixId },
                     });
                   }
                 }
@@ -644,3 +693,5 @@ export function registerDispatchWorkerCommand(
       }
     });
 }
+
+

--- a/src/scheduler/merge-fix.ts
+++ b/src/scheduler/merge-fix.ts
@@ -1,0 +1,278 @@
+import type { Blackboard } from '../blackboard.ts';
+import type { BlackboardProject, BlackboardWorkItem } from 'ivy-blackboard/src/types';
+import type { SessionLauncher } from './types.ts';
+import {
+  ensureWorktree,
+  resolveWorktreePath,
+  rebaseOnMain,
+  forcePushBranch,
+  commitAll,
+  pushBranch,
+  mergePR,
+  pullMain,
+} from './worktree.ts';
+
+/**
+ * Metadata shape for merge-fix recovery work items.
+ */
+export interface MergeFixMetadata {
+  merge_fix: true;
+  pr_number: number;
+  pr_url: string;
+  branch: string;
+  main_branch: string;
+  original_item_id: string;
+  original_issue_number?: number;
+  project_id: string;
+}
+
+/**
+ * Parse work item metadata to extract merge-fix fields.
+ * Returns null if the metadata does not represent a merge-fix item.
+ */
+export function parseMergeFixMeta(metadata: string | null): MergeFixMetadata | null {
+  if (!metadata) return null;
+  try {
+    const parsed = JSON.parse(metadata);
+    if (parsed.merge_fix === true && parsed.pr_number && parsed.branch && parsed.main_branch) {
+      return {
+        merge_fix: true,
+        pr_number: parsed.pr_number,
+        pr_url: parsed.pr_url,
+        branch: parsed.branch,
+        main_branch: parsed.main_branch,
+        original_item_id: parsed.original_item_id,
+        original_issue_number: parsed.original_issue_number,
+        project_id: parsed.project_id,
+      };
+    }
+  } catch {
+    // Invalid metadata JSON
+  }
+  return null;
+}
+
+/**
+ * Create a merge-fix recovery work item on the blackboard.
+ * Called when auto-merge fails on a trusted path.
+ *
+ * Returns the created work item ID.
+ */
+export function createMergeFixWorkItem(
+  bb: Blackboard,
+  opts: {
+    originalItemId: string;
+    prNumber: number;
+    prUrl: string;
+    branch: string;
+    mainBranch: string;
+    issueNumber?: number;
+    projectId: string;
+    originalTitle: string;
+    sessionId?: string;
+  }
+): string {
+  const itemId = `merge-fix-${opts.originalItemId}-${opts.prNumber}`;
+  const title = opts.issueNumber
+    ? `Fix merge conflict: PR #${opts.prNumber} for #${opts.issueNumber}`
+    : `Fix merge conflict: PR #${opts.prNumber}`;
+
+  const description = [
+    `Auto-merge failed for PR #${opts.prNumber}.`,
+    '',
+    `- **PR URL:** ${opts.prUrl}`,
+    `- **Branch:** ${opts.branch}`,
+    `- **Base:** ${opts.mainBranch}`,
+    `- **Original task:** ${opts.originalTitle}`,
+    '',
+    'This work item will attempt to rebase the branch on main and re-merge.',
+    'If rebase has conflicts, a Claude agent will resolve them.',
+  ].join('\n');
+
+  const metadata: MergeFixMetadata = {
+    merge_fix: true,
+    pr_number: opts.prNumber,
+    pr_url: opts.prUrl,
+    branch: opts.branch,
+    main_branch: opts.mainBranch,
+    original_item_id: opts.originalItemId,
+    original_issue_number: opts.issueNumber,
+    project_id: opts.projectId,
+  };
+
+  bb.createWorkItem({
+    id: itemId,
+    title,
+    description,
+    project: opts.projectId,
+    priority: 'P1',
+    source: 'merge-fix',
+    metadata: JSON.stringify(metadata),
+  });
+
+  bb.appendEvent({
+    actorId: opts.sessionId,
+    targetId: opts.originalItemId,
+    summary: `Created merge-fix work item "${itemId}" for PR #${opts.prNumber}`,
+    metadata: { mergeFixItemId: itemId, prNumber: opts.prNumber },
+  });
+
+  return itemId;
+}
+
+/**
+ * Execute the merge-fix recovery flow:
+ * 1. Ensure worktree exists for the PR branch
+ * 2. Attempt rebase on main
+ * 3. If clean: force-push and re-merge
+ * 4. If conflicts: launch Claude agent to resolve, then commit + push + merge
+ * 5. On success: pull main to sync
+ */
+export async function runMergeFix(
+  bb: Blackboard,
+  item: BlackboardWorkItem,
+  meta: MergeFixMetadata,
+  project: BlackboardProject,
+  sessionId: string,
+  launcher: SessionLauncher,
+  timeoutMs: number
+): Promise<void> {
+  const expectedPath = resolveWorktreePath(project.local_path, meta.branch, meta.project_id);
+  const worktreePath = await ensureWorktree(project.local_path, expectedPath, meta.branch);
+
+  bb.appendEvent({
+    actorId: sessionId,
+    targetId: item.item_id,
+    summary: `Merge-fix: ensured worktree for branch ${meta.branch} at ${worktreePath}`,
+  });
+
+  // Step 1: Try rebase on main
+  const rebased = await rebaseOnMain(worktreePath, meta.main_branch);
+
+  if (rebased) {
+    // Clean rebase — force-push and re-merge
+    await forcePushBranch(worktreePath, meta.branch);
+    bb.appendEvent({
+      actorId: sessionId,
+      targetId: item.item_id,
+      summary: `Merge-fix: rebased ${meta.branch} on ${meta.main_branch} and force-pushed`,
+    });
+
+    const merged = await mergePR(worktreePath, meta.pr_number);
+    if (merged) {
+      try {
+        await pullMain(project.local_path, meta.main_branch);
+      } catch { /* non-fatal */ }
+
+      bb.appendEvent({
+        actorId: sessionId,
+        targetId: item.item_id,
+        summary: `Merge-fix: successfully merged PR #${meta.pr_number} after rebase`,
+        metadata: { prNumber: meta.pr_number, method: 'rebase' },
+      });
+      return;
+    }
+    // Merge still failed after rebase — fall through to agent
+  }
+
+  // Step 2: Rebase failed or merge still failing — launch agent to resolve conflicts
+  bb.appendEvent({
+    actorId: sessionId,
+    targetId: item.item_id,
+    summary: `Merge-fix: rebase had conflicts, launching agent to resolve`,
+  });
+
+  // Start a merge so the agent can see conflict markers
+  try {
+    await mergeMainIntoWorktree(worktreePath, meta.main_branch);
+  } catch {
+    // Expected — merge will fail with conflicts, leaving markers in files
+  }
+
+  const prompt = buildMergeFixPrompt(meta);
+  const result = await launcher({
+    workDir: worktreePath,
+    prompt,
+    timeoutMs,
+    sessionId: `${sessionId}-merge-fix`,
+    disableMcp: true,
+  });
+
+  if (result.exitCode !== 0) {
+    throw new Error(`Agent failed to resolve merge conflicts (exit ${result.exitCode})`);
+  }
+
+  // Agent resolved conflicts — commit, push, merge
+  const sha = await commitAll(worktreePath, `Resolve merge conflicts for PR #${meta.pr_number}`);
+  if (sha) {
+    await pushBranch(worktreePath, meta.branch);
+  }
+
+  const merged = await mergePR(worktreePath, meta.pr_number);
+  if (!merged) {
+    throw new Error(`PR #${meta.pr_number} still cannot be merged after conflict resolution`);
+  }
+
+  try {
+    await pullMain(project.local_path, meta.main_branch);
+  } catch { /* non-fatal */ }
+
+  bb.appendEvent({
+    actorId: sessionId,
+    targetId: item.item_id,
+    summary: `Merge-fix: successfully merged PR #${meta.pr_number} after agent conflict resolution`,
+    metadata: { prNumber: meta.pr_number, method: 'agent-resolve', commitSha: sha },
+  });
+}
+
+/**
+ * Start a merge of main into the worktree branch (will leave conflict markers).
+ */
+async function mergeMainIntoWorktree(
+  worktreePath: string,
+  mainBranch: string
+): Promise<void> {
+  const run = async (args: string[]) => {
+    const proc = Bun.spawn(['git', ...args], {
+      cwd: worktreePath,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      throw new Error(`git ${args[0]} failed (exit ${exitCode}): ${stderr.trim()}`);
+    }
+    return stdout.trim();
+  };
+
+  try {
+    await run(['fetch', 'origin']);
+  } catch { /* may fail if no remote */ }
+
+  // This will fail with conflicts — that's expected
+  await run(['merge', `origin/${mainBranch}`, '--no-commit']);
+}
+
+/**
+ * Build the prompt for a Claude agent resolving merge conflicts.
+ */
+function buildMergeFixPrompt(meta: MergeFixMetadata): string {
+  return [
+    `You are resolving merge conflicts in branch "${meta.branch}".`,
+    '',
+    `PR #${meta.pr_number}: ${meta.pr_url}`,
+    `The branch needs to be merged into ${meta.main_branch} but has conflicts.`,
+    '',
+    'The working directory has conflict markers in files. Your job:',
+    '1. Find all files with conflict markers (<<<<<<< / ======= / >>>>>>>)',
+    '2. Resolve each conflict by keeping the correct code',
+    '3. Stage all resolved files with `git add`',
+    '',
+    'Do NOT commit, push, or create PRs. Just resolve the conflicts and stage the files.',
+    'When done, summarize which files you resolved and how.',
+  ].join('\n');
+}

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -7,6 +7,7 @@ import {
   getCurrentBranch,
   createWorktree,
   removeWorktree,
+  resolveWorktreePath,
   commitAll,
   pushBranch,
   createPR,
@@ -17,6 +18,7 @@ import {
 } from './worktree.ts';
 import { parseSpecFlowMeta } from './specflow-types.ts';
 import { runSpecFlowPhase } from './specflow-runner.ts';
+import { parseMergeFixMeta, createMergeFixWorkItem, runMergeFix } from './merge-fix.ts';
 import type {
   DispatchOptions,
   DispatchResult,
@@ -400,6 +402,53 @@ export async function dispatch(
         continue;
       }
 
+      // Determine if this is a merge-fix recovery work item
+      const mfMeta = parseMergeFixMeta(item.metadata);
+      if (mfMeta && project) {
+        const mfWorktreePath = resolveWorktreePath(project.local_path, mfMeta.branch, mfMeta.project_id);
+        try {
+          await runMergeFix(bb, item, mfMeta, project, sessionId, launcher, opts.timeout * 60 * 1000);
+          bb.completeWorkItem(item.item_id, sessionId);
+
+          const durationMs = Date.now() - startTime;
+          bb.appendEvent({
+            actorId: sessionId,
+            targetId: item.item_id,
+            summary: `Merge-fix completed for PR #${mfMeta.pr_number} (${Math.round(durationMs / 1000)}s)`,
+            metadata: { prNumber: mfMeta.pr_number, durationMs },
+          });
+
+          result.dispatched.push({
+            itemId: item.item_id,
+            title: item.title,
+            projectId: item.project_id ?? '(none)',
+            sessionId,
+            exitCode: 0,
+            completed: true,
+            durationMs,
+          });
+        } catch (err: unknown) {
+          const msg = err instanceof Error ? err.message : String(err);
+          const durationMs = Date.now() - startTime;
+          try { bb.releaseWorkItem(item.item_id, sessionId); } catch { /* best effort */ }
+          bb.appendEvent({
+            actorId: sessionId,
+            targetId: item.item_id,
+            summary: `Merge-fix failed for PR #${mfMeta.pr_number}: ${msg}`,
+            metadata: { error: msg, durationMs },
+          });
+          result.errors.push({
+            itemId: item.item_id,
+            title: item.title,
+            error: `Merge-fix failed: ${msg}`,
+          });
+        } finally {
+          try { await removeWorktree(project.local_path, mfWorktreePath); } catch { /* best effort */ }
+          bb.deregisterAgent(sessionId);
+        }
+        continue;
+      }
+
       const prompt = buildPrompt(item, sessionId);
 
       // Worktree setup for GitHub items
@@ -514,20 +563,44 @@ export async function dispatch(
                         });
                       }
                     } else {
+                      // Create recovery work item for merge failure
+                      const mergeFixId = createMergeFixWorkItem(bb, {
+                        originalItemId: item.item_id,
+                        prNumber: pr.number,
+                        prUrl: pr.url,
+                        branch: branch!,
+                        mainBranch: mainBranch!,
+                        issueNumber: ghMeta.issueNumber,
+                        projectId: item.project_id!,
+                        originalTitle: item.title,
+                        sessionId,
+                      });
                       bb.appendEvent({
                         actorId: sessionId,
                         targetId: item.item_id,
-                        summary: `Auto-merge failed for PR #${pr.number} — left open for manual review`,
-                        metadata: { prNumber: pr.number, autoMerge: false },
+                        summary: `Auto-merge failed for PR #${pr.number} — created recovery item ${mergeFixId}`,
+                        metadata: { prNumber: pr.number, autoMerge: false, mergeFixItemId: mergeFixId },
                       });
                     }
                   } catch (mergeErr: unknown) {
                     const mergeMsg = mergeErr instanceof Error ? mergeErr.message : String(mergeErr);
+                    // Create recovery work item for merge error
+                    const mergeFixId = createMergeFixWorkItem(bb, {
+                      originalItemId: item.item_id,
+                      prNumber: pr.number,
+                      prUrl: pr.url,
+                      branch: branch!,
+                      mainBranch: mainBranch!,
+                      issueNumber: ghMeta.issueNumber,
+                      projectId: item.project_id!,
+                      originalTitle: item.title,
+                      sessionId,
+                    });
                     bb.appendEvent({
                       actorId: sessionId,
                       targetId: item.item_id,
-                      summary: `Auto-merge error for PR #${pr.number} (non-fatal): ${mergeMsg}`,
-                      metadata: { prNumber: pr.number, error: mergeMsg },
+                      summary: `Auto-merge error for PR #${pr.number}: ${mergeMsg} — created recovery item ${mergeFixId}`,
+                      metadata: { prNumber: pr.number, error: mergeMsg, mergeFixItemId: mergeFixId },
                     });
                   }
                 }

--- a/test/merge-fix.test.ts
+++ b/test/merge-fix.test.ts
@@ -1,0 +1,180 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import { createTestContext, cleanupTestContext, type TestContext } from './helpers.ts';
+import {
+  parseMergeFixMeta,
+  createMergeFixWorkItem,
+  type MergeFixMetadata,
+} from '../src/scheduler/merge-fix.ts';
+import { registerProject } from 'ivy-blackboard/src/project';
+import { createWorkItem } from 'ivy-blackboard/src/work';
+
+let ctx: TestContext;
+
+beforeEach(() => {
+  ctx = createTestContext();
+});
+
+afterEach(() => {
+  cleanupTestContext(ctx);
+});
+
+describe('parseMergeFixMeta', () => {
+  test('returns null for null metadata', () => {
+    expect(parseMergeFixMeta(null)).toBeNull();
+  });
+
+  test('returns null for non-merge-fix metadata', () => {
+    const meta = JSON.stringify({ github_issue_number: 1, github_repo: 'owner/repo' });
+    expect(parseMergeFixMeta(meta)).toBeNull();
+  });
+
+  test('returns null for invalid JSON', () => {
+    expect(parseMergeFixMeta('not json')).toBeNull();
+  });
+
+  test('returns null when merge_fix is not true', () => {
+    const meta = JSON.stringify({ merge_fix: false, pr_number: 1, branch: 'b', main_branch: 'm' });
+    expect(parseMergeFixMeta(meta)).toBeNull();
+  });
+
+  test('returns null when required fields are missing', () => {
+    const meta = JSON.stringify({ merge_fix: true, pr_number: 1 });
+    expect(parseMergeFixMeta(meta)).toBeNull();
+  });
+
+  test('parses valid merge-fix metadata', () => {
+    const input: MergeFixMetadata = {
+      merge_fix: true,
+      pr_number: 42,
+      pr_url: 'https://github.com/owner/repo/pull/42',
+      branch: 'fix/issue-10',
+      main_branch: 'main',
+      original_item_id: 'gh-repo-10',
+      original_issue_number: 10,
+      project_id: 'my-project',
+    };
+    const result = parseMergeFixMeta(JSON.stringify(input));
+    expect(result).not.toBeNull();
+    expect(result!.merge_fix).toBe(true);
+    expect(result!.pr_number).toBe(42);
+    expect(result!.pr_url).toBe('https://github.com/owner/repo/pull/42');
+    expect(result!.branch).toBe('fix/issue-10');
+    expect(result!.main_branch).toBe('main');
+    expect(result!.original_item_id).toBe('gh-repo-10');
+    expect(result!.original_issue_number).toBe(10);
+    expect(result!.project_id).toBe('my-project');
+  });
+
+  test('handles missing optional fields', () => {
+    const meta = JSON.stringify({
+      merge_fix: true,
+      pr_number: 5,
+      pr_url: 'https://example.com/pull/5',
+      branch: 'fix/issue-3',
+      main_branch: 'main',
+      original_item_id: 'item-1',
+      project_id: 'proj-a',
+    });
+    const result = parseMergeFixMeta(meta);
+    expect(result).not.toBeNull();
+    expect(result!.original_issue_number).toBeUndefined();
+  });
+});
+
+describe('createMergeFixWorkItem', () => {
+  test('creates a P1 work item with correct ID and title', () => {
+    registerProject(ctx.bb.db, { id: 'proj-a', name: 'Project A', path: '/tmp/proj-a' });
+
+    const itemId = createMergeFixWorkItem(ctx.bb, {
+      originalItemId: 'gh-repo-10',
+      prNumber: 42,
+      prUrl: 'https://github.com/owner/repo/pull/42',
+      branch: 'fix/issue-10',
+      mainBranch: 'main',
+      issueNumber: 10,
+      projectId: 'proj-a',
+      originalTitle: 'Fix the bug',
+      sessionId: 'session-1',
+    });
+
+    expect(itemId).toBe('merge-fix-gh-repo-10-42');
+
+    const items = ctx.bb.listWorkItems({ status: 'available' });
+    const mergeFixItem = items.find((i) => i.item_id === itemId);
+    expect(mergeFixItem).toBeDefined();
+    expect(mergeFixItem!.title).toBe('Fix merge conflict: PR #42 for #10');
+    expect(mergeFixItem!.priority).toBe('P1');
+    expect(mergeFixItem!.source).toBe('merge-fix');
+    expect(mergeFixItem!.project_id).toBe('proj-a');
+
+    // Verify metadata
+    const meta = JSON.parse(mergeFixItem!.metadata!);
+    expect(meta.merge_fix).toBe(true);
+    expect(meta.pr_number).toBe(42);
+    expect(meta.branch).toBe('fix/issue-10');
+    expect(meta.main_branch).toBe('main');
+    expect(meta.original_item_id).toBe('gh-repo-10');
+  });
+
+  test('creates title without issue number when not provided', () => {
+    registerProject(ctx.bb.db, { id: 'proj-a', name: 'Project A', path: '/tmp/proj-a' });
+
+    const itemId = createMergeFixWorkItem(ctx.bb, {
+      originalItemId: 'item-1',
+      prNumber: 5,
+      prUrl: 'https://example.com/pull/5',
+      branch: 'fix/task-1',
+      mainBranch: 'main',
+      projectId: 'proj-a',
+      originalTitle: 'Some task',
+    });
+
+    const items = ctx.bb.listWorkItems({ status: 'available' });
+    const mergeFixItem = items.find((i) => i.item_id === itemId);
+    expect(mergeFixItem!.title).toBe('Fix merge conflict: PR #5');
+  });
+
+  test('logs event linking merge-fix to original item', () => {
+    registerProject(ctx.bb.db, { id: 'proj-a', name: 'Project A', path: '/tmp/proj-a' });
+
+    createMergeFixWorkItem(ctx.bb, {
+      originalItemId: 'gh-repo-10',
+      prNumber: 42,
+      prUrl: 'https://github.com/owner/repo/pull/42',
+      branch: 'fix/issue-10',
+      mainBranch: 'main',
+      issueNumber: 10,
+      projectId: 'proj-a',
+      originalTitle: 'Fix the bug',
+      sessionId: 'session-1',
+    });
+
+    const events = ctx.bb.eventQueries.getRecent(10);
+    const createEvent = events.find((e) => e.summary.includes('Created merge-fix work item'));
+    expect(createEvent).toBeDefined();
+    expect(createEvent!.summary).toContain('merge-fix-gh-repo-10-42');
+    expect(createEvent!.summary).toContain('PR #42');
+  });
+
+  test('description includes PR URL and branch info', () => {
+    registerProject(ctx.bb.db, { id: 'proj-a', name: 'Project A', path: '/tmp/proj-a' });
+
+    const itemId = createMergeFixWorkItem(ctx.bb, {
+      originalItemId: 'item-1',
+      prNumber: 7,
+      prUrl: 'https://github.com/owner/repo/pull/7',
+      branch: 'fix/issue-5',
+      mainBranch: 'main',
+      issueNumber: 5,
+      projectId: 'proj-a',
+      originalTitle: 'Add feature X',
+    });
+
+    const items = ctx.bb.listWorkItems({ status: 'available' });
+    const mergeFixItem = items.find((i) => i.item_id === itemId);
+    expect(mergeFixItem!.description).toContain('https://github.com/owner/repo/pull/7');
+    expect(mergeFixItem!.description).toContain('fix/issue-5');
+    expect(mergeFixItem!.description).toContain('main');
+    expect(mergeFixItem!.description).toContain('Add feature X');
+  });
+});


### PR DESCRIPTION
Fixes #16

Automated fix for: Issue #16: Create recovery work item when PR merge fails on trusted path