### PR TITLE
Fix #57: Issue #57: Mycelia evaluator: deduplicate alerts and include response content

### DIFF
--- a/src/check/runner.ts
+++ b/src/check/runner.ts
@@ -12,6 +12,7 @@ import { setPrReviewBlackboardAccessor, resetPrReviewBlackboardAccessor } from '
 import { setCleanupBlackboard, resetCleanupBlackboard } from '../evaluators/specflow-cleanup.ts';
 import { setOrchestratorBlackboard, resetOrchestratorBlackboard } from '../evaluators/specflow-orchestrate.ts';
 import { setWatchdogBlackboard, resetWatchdogBlackboard } from '../evaluators/agent-watchdog.ts';
+import { setMyceliaBlackboardAccessor, resetMyceliaBlackboardAccessor } from '../evaluators/mycelia.ts';
 import { releaseOrphanedFeatures } from '../scheduler/specflow/orchestrator.ts';
 import { setReviewCycleAccessor, resetReviewCycleAccessor } from '../scheduler/worktree.ts';
 import type {
@@ -105,6 +106,7 @@ export async function runChecks(
   setCleanupBlackboard(bb);
   setOrchestratorBlackboard(bb);
   setWatchdogBlackboard(bb);
+  setMyceliaBlackboardAccessor(bb);
   setReviewCycleAccessor(bb);
 
   const results: CheckResult[] = [];
@@ -181,6 +183,7 @@ export async function runChecks(
   resetCleanupBlackboard();
   resetOrchestratorBlackboard();
   resetWatchdogBlackboard();
+  resetMyceliaBlackboardAccessor();
   resetReviewCycleAccessor();
 
   return {

--- a/src/evaluators/mycelia.ts
+++ b/src/evaluators/mycelia.ts
@@ -22,43 +22,56 @@ interface MyceliaRequest {
   expires_at: string;
 }
 
+interface MyceliaResponse {
+  id: string;
+  responder_id: string;
+  responder_name: string;
+  body: string;
+  confidence: number;
+  created_at: string;
+}
+
+interface MyceliaRequestDetail {
+  id: string;
+  requester_id: string;
+  title: string;
+  body: string;
+  request_type: string;
+  status: string;
+  response_count: number;
+  max_responses: number;
+  created_at: string;
+  expires_at: string;
+  responses: MyceliaResponse[];
+}
+
 interface MyceliaApiResponse {
   ok: boolean;
   data?: {
     requests?: MyceliaRequest[];
+    request?: MyceliaRequestDetail;
     agent?: { trust_score: number; request_count: number; response_count: number };
   };
 }
 
-// ─── Injectable fetcher (for testing) ───────────────────────────────────────
+export type MyceliaBlackboardAccessor = {
+  findLastEventByCheckName(checkName: string): { metadata: string | null } | null;
+  appendEvent(opts: {
+    summary: string;
+    metadata?: Record<string, unknown>;
+  }): void;
+};
 
-export type MyceliaFetcher = (command: string[]) => Promise<MyceliaApiResponse | null>;
+// ─── Injectable API fetcher (for testing) ──────────────────────────────────
 
-let myceliaFetcher: MyceliaFetcher = defaultMyceliaFetcher;
+export type MyceliaApiFetcher = (path: string, configPath: string) => Promise<MyceliaApiResponse | null>;
 
-async function defaultMyceliaFetcher(command: string[]): Promise<MyceliaApiResponse | null> {
-  try {
-    const proc = Bun.spawn(['bun', 'run', ...command], {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-
-    const output = await new Response(proc.stdout).text();
-    await proc.exited;
-
-    if (proc.exitCode !== 0) return null;
-
-    // The CLI outputs formatted text, not JSON. Use the API directly.
-    return null;
-  } catch {
-    return null;
-  }
-}
+let apiFetcher: MyceliaApiFetcher = defaultApiFetcher;
 
 /**
  * Fetch from Mycelia API directly using the config file.
  */
-async function fetchMyceliaApi(path: string, configPath: string): Promise<MyceliaApiResponse | null> {
+async function defaultApiFetcher(path: string, configPath: string): Promise<MyceliaApiResponse | null> {
   try {
     const configFile = Bun.file(configPath);
     if (!await configFile.exists()) return null;
@@ -75,12 +88,16 @@ async function fetchMyceliaApi(path: string, configPath: string): Promise<Myceli
   }
 }
 
-export function setMyceliaFetcher(fetcher: MyceliaFetcher): void {
-  myceliaFetcher = fetcher;
+async function fetchMyceliaApi(path: string, configPath: string): Promise<MyceliaApiResponse | null> {
+  return apiFetcher(path, configPath);
+}
+
+export function setMyceliaFetcher(fetcher: MyceliaApiFetcher): void {
+  apiFetcher = fetcher;
 }
 
 export function resetMyceliaFetcher(): void {
-  myceliaFetcher = defaultMyceliaFetcher;
+  apiFetcher = defaultApiFetcher;
 }
 
 // ─── Email notification ─────────────────────────────────────────────────────
@@ -109,6 +126,18 @@ export function setEmailSender(sender: EmailSender): void {
 
 export function resetEmailSender(): void {
   emailSender = defaultEmailSender;
+}
+
+// ─── Blackboard accessor ─────────────────────────────────────────────────
+
+let bbAccessor: MyceliaBlackboardAccessor | null = null;
+
+export function setMyceliaBlackboardAccessor(accessor: MyceliaBlackboardAccessor): void {
+  bbAccessor = accessor;
+}
+
+export function resetMyceliaBlackboardAccessor(): void {
+  bbAccessor = null;
 }
 
 // ─── Config parsing ─────────────────────────────────────────────────────────
@@ -175,21 +204,108 @@ export async function evaluateMycelia(item: ChecklistItem): Promise<CheckResult>
       }
     }
 
-    // Build alert details
-    const claimableCount = claimable.length;
-    const claimableTitles = claimable.map((r) =>
-      `• ${r.title} (${r.request_type}, ${r.response_count}/${r.max_responses} responses)`
-    );
+    // Load previous state from blackboard (if available)
+    let previousSeenIds: string[] = [];
+    let previousResponseCounts: Record<string, number> = {};
 
-    if (claimableCount > 0) {
-      const summary = `Mycelia: ${claimableCount} open request${claimableCount > 1 ? 's' : ''} available to claim`;
+    if (bbAccessor) {
+      const lastEvent = bbAccessor.findLastEventByCheckName(item.name);
+      if (lastEvent?.metadata) {
+        try {
+          const metadata = JSON.parse(lastEvent.metadata);
+          previousSeenIds = metadata.seenRequestIds ?? [];
+          previousResponseCounts = metadata.responseCountsByRequestId ?? {};
+        } catch {
+          // Ignore parse errors
+        }
+      }
+    }
+
+    // Deduplicate claimable requests — only alert on new ones
+    const currentIds = claimable.map((r) => r.id);
+    const newRequests = claimable.filter((r) => !previousSeenIds.includes(r.id));
+    const newCount = newRequests.length;
+
+    // Check our own requests for new responses
+    const ourRequests = requests.filter((r) => r.requester_id === config.agentId);
+    const newResponses: Array<{ request: MyceliaRequestDetail; newResponseCount: number }> = [];
+
+    for (const req of ourRequests) {
+      const previousCount = previousResponseCounts[req.id] ?? 0;
+      if (req.response_count > previousCount) {
+        // Fetch full request details to get response bodies
+        const detailData = await fetchMyceliaApi(`/v1/requests/${req.id}`, config.clientPath);
+        if (detailData?.ok && detailData.data?.request) {
+          newResponses.push({
+            request: detailData.data.request,
+            newResponseCount: req.response_count - previousCount,
+          });
+        }
+      }
+    }
+
+    // Update response count tracking
+    const updatedResponseCounts: Record<string, number> = {};
+    for (const req of ourRequests) {
+      updatedResponseCounts[req.id] = req.response_count;
+    }
+
+    // Save state to blackboard for next check
+    if (bbAccessor) {
+      bbAccessor.appendEvent({
+        summary: `Mycelia check: ${newCount} new claimable, ${newResponses.length} new responses`,
+        metadata: {
+          checkName: item.name,
+          seenRequestIds: currentIds,
+          responseCountsByRequestId: updatedResponseCounts,
+          newClaimableCount: newCount,
+          newResponseCount: newResponses.length,
+        },
+      });
+    }
+
+    // Handle new responses first
+    if (newResponses.length > 0 && config.emailTo) {
+      for (const { request, newResponseCount } of newResponses) {
+        const emailSubject = `[Mycelia] ${newResponseCount} new response${newResponseCount > 1 ? 's' : ''} to: ${request.title}`;
+
+        const responseSections = request.responses.slice(-newResponseCount).map((resp) => {
+          return [
+            `From: ${resp.responder_name}`,
+            `Confidence: ${resp.confidence}/10`,
+            ``,
+            resp.body,
+            ``,
+            `---`,
+          ].join('\n');
+        });
+
+        const emailBody = [
+          `Your request "${request.title}" received ${newResponseCount} new response${newResponseCount > 1 ? 's' : ''}:\n`,
+          ...responseSections,
+          '',
+          `To rate responses, tell Ivy: "mycelia rate [RESPONSE_ID]"`,
+          `View full request: https://mycelia.fyi/requests/${request.id}`,
+        ].join('\n');
+
+        await emailSender(config.emailTo, emailSubject, emailBody);
+      }
+    }
+
+    // Handle new claimable requests
+    if (newCount > 0) {
+      const summary = `Mycelia: ${newCount} NEW request${newCount > 1 ? 's' : ''} available to claim`;
+
+      const newTitles = newRequests.map((r) =>
+        `• ${r.title} (${r.request_type}, ${r.response_count}/${r.max_responses} responses)`
+      );
 
       // Send email notification if configured
       if (config.emailTo) {
-        const emailSubject = `[Mycelia] ${claimableCount} request${claimableCount > 1 ? 's' : ''} available`;
+        const emailSubject = `[Mycelia] ${newCount} NEW request${newCount > 1 ? 's' : ''} available`;
         const emailBody = [
-          `${claimableCount} open request${claimableCount > 1 ? 's' : ''} on the Mycelia network:\n`,
-          ...claimableTitles,
+          `${newCount} new request${newCount > 1 ? 's' : ''} on the Mycelia network:\n`,
+          ...newTitles,
           '',
           'To claim, tell Ivy: "check mycelia" or "mycelia browse"',
         ].join('\n');
@@ -203,8 +319,26 @@ export async function evaluateMycelia(item: ChecklistItem): Promise<CheckResult>
         summary,
         details: {
           configured: true,
-          claimableCount,
-          claimable: claimableTitles,
+          claimableCount: claimable.length,
+          newClaimableCount: newCount,
+          newClaimable: newTitles,
+          newResponseCount: newResponses.length,
+          trustScore,
+        },
+      };
+    }
+
+    // No new claimable requests, but check for new responses
+    if (newResponses.length > 0) {
+      return {
+        item,
+        status: 'alert',
+        summary: `Mycelia: ${newResponses.length} new response${newResponses.length > 1 ? 's' : ''} to your requests`,
+        details: {
+          configured: true,
+          claimableCount: claimable.length,
+          newClaimableCount: 0,
+          newResponseCount: newResponses.length,
           trustScore,
         },
       };
@@ -213,10 +347,12 @@ export async function evaluateMycelia(item: ChecklistItem): Promise<CheckResult>
     return {
       item,
       status: 'ok',
-      summary: `Mycelia: no claimable requests. Trust: ${trustScore ?? 'unknown'}`,
+      summary: `Mycelia: no new activity. Trust: ${trustScore ?? 'unknown'}`,
       details: {
         configured: true,
-        claimableCount: 0,
+        claimableCount: claimable.length,
+        newClaimableCount: 0,
+        newResponseCount: 0,
         trustScore,
       },
     };

--- a/test/mycelia.test.ts
+++ b/test/mycelia.test.ts
@@ -1,0 +1,472 @@
+import { describe, test, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  evaluateMycelia,
+  setMyceliaFetcher,
+  resetMyceliaFetcher,
+  setEmailSender,
+  resetEmailSender,
+  setMyceliaBlackboardAccessor,
+  resetMyceliaBlackboardAccessor,
+  type MyceliaApiFetcher,
+  type EmailSender,
+  type MyceliaBlackboardAccessor,
+} from '../src/evaluators/mycelia.ts';
+import type { ChecklistItem } from '../src/parser/types.ts';
+
+function makeItem(overrides: Partial<ChecklistItem> = {}): ChecklistItem {
+  return {
+    name: 'Mycelia Network',
+    type: 'mycelia',
+    severity: 'medium',
+    channels: ['terminal'],
+    enabled: true,
+    description: 'Check Mycelia network for requests',
+    config: {
+      config_path: '/fake/config.json',
+      agent_id: 'test-agent-id',
+      email_to: 'test@example.com',
+    },
+    ...overrides,
+  };
+}
+
+describe('Mycelia evaluator - deduplication', () => {
+  let sentEmails: Array<{ to: string; subject: string; body: string }> = [];
+  let appendedEvents: Array<{ summary: string; metadata?: Record<string, unknown> }> = [];
+  let storedMetadata: Record<string, unknown> = {};
+
+  const mockEmailSender: EmailSender = async (to, subject, body) => {
+    sentEmails.push({ to, subject, body });
+    return true;
+  };
+
+  const mockBlackboard: MyceliaBlackboardAccessor = {
+    findLastEventByCheckName: (_checkName: string) => {
+      if (Object.keys(storedMetadata).length === 0) return null;
+      return { metadata: JSON.stringify(storedMetadata) };
+    },
+    appendEvent: (opts) => {
+      appendedEvents.push(opts);
+      if (opts.metadata) {
+        storedMetadata = opts.metadata;
+      }
+    },
+  };
+
+  beforeEach(() => {
+    sentEmails = [];
+    appendedEvents = [];
+    storedMetadata = {};
+    setEmailSender(mockEmailSender);
+    setMyceliaBlackboardAccessor(mockBlackboard);
+  });
+
+  afterEach(() => {
+    resetEmailSender();
+    resetMyceliaFetcher();
+    resetMyceliaBlackboardAccessor();
+  });
+
+  test('alerts on first run with claimable requests', async () => {
+    const mockFetcher: MyceliaApiFetcher = async (path, _configPath) => {
+      if (path === '/v1/requests') {
+        return {
+          ok: true,
+          data: {
+            requests: [
+              {
+                id: 'req-1',
+                requester_id: 'other-agent',
+                title: 'Help needed',
+                request_type: 'review',
+                status: 'open',
+                response_count: 0,
+                max_responses: 3,
+                created_at: new Date().toISOString(),
+                expires_at: new Date(Date.now() + 86400000).toISOString(),
+              },
+            ],
+          },
+        };
+      }
+      if (path === '/v1/agents/test-agent-id') {
+        return {
+          ok: true,
+          data: { agent: { trust_score: 85, request_count: 5, response_count: 10 } },
+        };
+      }
+      return null;
+    };
+
+    setMyceliaFetcher(mockFetcher);
+
+    const result = await evaluateMycelia(makeItem());
+
+    expect(result.status).toBe('alert');
+    expect(result.summary).toContain('1 NEW request');
+    expect(sentEmails).toHaveLength(1);
+    expect(sentEmails[0].subject).toContain('[Mycelia] 1 NEW request available');
+    expect(sentEmails[0].body).toContain('Help needed');
+
+    // Verify metadata stored
+    expect(appendedEvents).toHaveLength(1);
+    expect(appendedEvents[0].metadata?.seenRequestIds).toEqual(['req-1']);
+  });
+
+  test('does NOT alert on second run with same requests', async () => {
+    const mockFetcher: MyceliaApiFetcher = async (path, _configPath) => {
+      if (path === '/v1/requests') {
+        return {
+          ok: true,
+          data: {
+            requests: [
+              {
+                id: 'req-1',
+                requester_id: 'other-agent',
+                title: 'Help needed',
+                request_type: 'review',
+                status: 'open',
+                response_count: 0,
+                max_responses: 3,
+                created_at: new Date().toISOString(),
+                expires_at: new Date(Date.now() + 86400000).toISOString(),
+              },
+            ],
+          },
+        };
+      }
+      if (path === '/v1/agents/test-agent-id') {
+        return {
+          ok: true,
+          data: { agent: { trust_score: 85, request_count: 5, response_count: 10 } },
+        };
+      }
+      return null;
+    };
+
+    setMyceliaFetcher(mockFetcher);
+
+    // First run
+    await evaluateMycelia(makeItem());
+    sentEmails = [];
+    appendedEvents = [];
+
+    // Second run with same request
+    const result = await evaluateMycelia(makeItem());
+
+    expect(result.status).toBe('ok');
+    expect(result.summary).toContain('no new activity');
+    expect(sentEmails).toHaveLength(0);
+  });
+
+  test('alerts only on NEW requests when some are already seen', async () => {
+    const mockFetcher: MyceliaApiFetcher = async (path, _configPath) => {
+      if (path === '/v1/requests') {
+        return {
+          ok: true,
+          data: {
+            requests: [
+              {
+                id: 'req-1',
+                requester_id: 'other-agent',
+                title: 'Old request',
+                request_type: 'review',
+                status: 'open',
+                response_count: 0,
+                max_responses: 3,
+                created_at: new Date().toISOString(),
+                expires_at: new Date(Date.now() + 86400000).toISOString(),
+              },
+              {
+                id: 'req-2',
+                requester_id: 'other-agent',
+                title: 'New request',
+                request_type: 'review',
+                status: 'open',
+                response_count: 0,
+                max_responses: 3,
+                created_at: new Date().toISOString(),
+                expires_at: new Date(Date.now() + 86400000).toISOString(),
+              },
+            ],
+          },
+        };
+      }
+      if (path === '/v1/agents/test-agent-id') {
+        return {
+          ok: true,
+          data: { agent: { trust_score: 85, request_count: 5, response_count: 10 } },
+        };
+      }
+      return null;
+    };
+
+    setMyceliaFetcher(mockFetcher);
+
+    // Seed with req-1 already seen
+    storedMetadata = {
+      seenRequestIds: ['req-1'],
+      responseCountsByRequestId: {},
+    };
+
+    const result = await evaluateMycelia(makeItem());
+
+    expect(result.status).toBe('alert');
+    expect(result.summary).toContain('1 NEW request');
+    expect(sentEmails).toHaveLength(1);
+    expect(sentEmails[0].body).toContain('New request');
+    expect(sentEmails[0].body).not.toContain('Old request');
+  });
+});
+
+describe('Mycelia evaluator - response tracking', () => {
+  let sentEmails: Array<{ to: string; subject: string; body: string }> = [];
+  let appendedEvents: Array<{ summary: string; metadata?: Record<string, unknown> }> = [];
+  let storedMetadata: Record<string, unknown> = {};
+
+  const mockEmailSender: EmailSender = async (to, subject, body) => {
+    sentEmails.push({ to, subject, body });
+    return true;
+  };
+
+  const mockBlackboard: MyceliaBlackboardAccessor = {
+    findLastEventByCheckName: (_checkName: string) => {
+      if (Object.keys(storedMetadata).length === 0) return null;
+      return { metadata: JSON.stringify(storedMetadata) };
+    },
+    appendEvent: (opts) => {
+      appendedEvents.push(opts);
+      if (opts.metadata) {
+        storedMetadata = opts.metadata;
+      }
+    },
+  };
+
+  beforeEach(() => {
+    sentEmails = [];
+    appendedEvents = [];
+    storedMetadata = {};
+    setEmailSender(mockEmailSender);
+    setMyceliaBlackboardAccessor(mockBlackboard);
+  });
+
+  afterEach(() => {
+    resetEmailSender();
+    resetMyceliaFetcher();
+    resetMyceliaBlackboardAccessor();
+  });
+
+  test('alerts when our request receives new responses', async () => {
+    const mockFetcher: MyceliaFetcher = async (path) => {
+      if (path === '/v1/requests/our-req-1') {
+        return {
+          ok: true,
+          data: {
+            request: {
+              id: 'our-req-1',
+              requester_id: 'test-agent-id',
+              title: 'Our request',
+              body: 'Please review this',
+              request_type: 'review',
+              status: 'open',
+              response_count: 1,
+              max_responses: 3,
+              created_at: new Date().toISOString(),
+              expires_at: new Date(Date.now() + 86400000).toISOString(),
+              responses: [
+                {
+                  id: 'resp-1',
+                  responder_id: 'helper-agent',
+                  responder_name: 'Helper Bot',
+                  body: 'This looks great! Just a few minor suggestions...',
+                  confidence: 8,
+                  created_at: new Date().toISOString(),
+                },
+              ],
+            },
+          },
+        };
+      }
+      if (path === '/v1/requests') {
+        return {
+          ok: true,
+          data: {
+            requests: [
+              {
+                id: 'our-req-1',
+                requester_id: 'test-agent-id',
+                title: 'Our request',
+                request_type: 'review',
+                status: 'open',
+                response_count: 1,
+                max_responses: 3,
+                created_at: new Date().toISOString(),
+                expires_at: new Date(Date.now() + 86400000).toISOString(),
+              },
+            ],
+          },
+        };
+      }
+      if (path === '/v1/agents/test-agent-id') {
+        return {
+          ok: true,
+          data: { agent: { trust_score: 85, request_count: 5, response_count: 10 } },
+        };
+      }
+      return null;
+    };
+
+    setMyceliaFetcher(mockFetcher);
+
+    // Seed with response_count = 0
+    storedMetadata = {
+      seenRequestIds: [],
+      responseCountsByRequestId: { 'our-req-1': 0 },
+    };
+
+    const result = await evaluateMycelia(makeItem());
+
+    expect(result.status).toBe('alert');
+    expect(result.summary).toContain('1 new response');
+    expect(sentEmails).toHaveLength(1);
+    expect(sentEmails[0].subject).toContain('[Mycelia] 1 new response to: Our request');
+    expect(sentEmails[0].body).toContain('Helper Bot');
+    expect(sentEmails[0].body).toContain('Confidence: 8/10');
+    expect(sentEmails[0].body).toContain('This looks great! Just a few minor suggestions...');
+  });
+
+  test('does NOT alert when response count unchanged', async () => {
+    const mockFetcher: MyceliaApiFetcher = async (path, _configPath) => {
+      if (path === '/v1/requests') {
+        return {
+          ok: true,
+          data: {
+            requests: [
+              {
+                id: 'our-req-1',
+                requester_id: 'test-agent-id',
+                title: 'Our request',
+                request_type: 'review',
+                status: 'open',
+                response_count: 1,
+                max_responses: 3,
+                created_at: new Date().toISOString(),
+                expires_at: new Date(Date.now() + 86400000).toISOString(),
+              },
+            ],
+          },
+        };
+      }
+      if (path === '/v1/agents/test-agent-id') {
+        return {
+          ok: true,
+          data: { agent: { trust_score: 85, request_count: 5, response_count: 10 } },
+        };
+      }
+      return null;
+    };
+
+    setMyceliaFetcher(mockFetcher);
+
+    // Seed with response_count = 1 (same as current)
+    storedMetadata = {
+      seenRequestIds: [],
+      responseCountsByRequestId: { 'our-req-1': 1 },
+    };
+
+    const result = await evaluateMycelia(makeItem());
+
+    expect(result.status).toBe('ok');
+    expect(sentEmails).toHaveLength(0);
+  });
+
+  test('alerts with both new claimable requests AND new responses', async () => {
+    const mockFetcher: MyceliaFetcher = async (path) => {
+      if (path === '/v1/requests/our-req-1') {
+        return {
+          ok: true,
+          data: {
+            request: {
+              id: 'our-req-1',
+              requester_id: 'test-agent-id',
+              title: 'Our request',
+              body: 'Please review this',
+              request_type: 'review',
+              status: 'open',
+              response_count: 1,
+              max_responses: 3,
+              created_at: new Date().toISOString(),
+              expires_at: new Date(Date.now() + 86400000).toISOString(),
+              responses: [
+                {
+                  id: 'resp-1',
+                  responder_id: 'helper-agent',
+                  responder_name: 'Helper Bot',
+                  body: 'Looks good!',
+                  confidence: 9,
+                  created_at: new Date().toISOString(),
+                },
+              ],
+            },
+          },
+        };
+      }
+      if (path === '/v1/requests') {
+        return {
+          ok: true,
+          data: {
+            requests: [
+              {
+                id: 'our-req-1',
+                requester_id: 'test-agent-id',
+                title: 'Our request',
+                request_type: 'review',
+                status: 'open',
+                response_count: 1,
+                max_responses: 3,
+                created_at: new Date().toISOString(),
+                expires_at: new Date(Date.now() + 86400000).toISOString(),
+              },
+              {
+                id: 'req-2',
+                requester_id: 'other-agent',
+                title: 'New claimable request',
+                request_type: 'review',
+                status: 'open',
+                response_count: 0,
+                max_responses: 3,
+                created_at: new Date().toISOString(),
+                expires_at: new Date(Date.now() + 86400000).toISOString(),
+              },
+            ],
+          },
+        };
+      }
+      if (path === '/v1/agents/test-agent-id') {
+        return {
+          ok: true,
+          data: { agent: { trust_score: 85, request_count: 5, response_count: 10 } },
+        };
+      }
+      return null;
+    };
+
+    setMyceliaFetcher(mockFetcher);
+
+    // Seed with no previous data
+    storedMetadata = {
+      seenRequestIds: [],
+      responseCountsByRequestId: { 'our-req-1': 0 },
+    };
+
+    const result = await evaluateMycelia(makeItem());
+
+    expect(result.status).toBe('alert');
+    expect(result.summary).toContain('1 NEW request');
+
+    // Should send 2 emails: one for response, one for claimable
+    expect(sentEmails).toHaveLength(2);
+    expect(sentEmails.some(e => e.subject.includes('new response'))).toBe(true);
+    expect(sentEmails.some(e => e.subject.includes('NEW request'))).toBe(true);
+  });
+});

--- a/test/mycelia.test.ts
+++ b/test/mycelia.test.ts
@@ -13,6 +13,10 @@ import {
 } from '../src/evaluators/mycelia.ts';
 import type { ChecklistItem } from '../src/parser/types.ts';
 
+// ============================================================================
+// Test Factories and Utilities
+// ============================================================================
+
 function makeItem(overrides: Partial<ChecklistItem> = {}): ChecklistItem {
   return {
     name: 'Mycelia Network',
@@ -30,9 +34,100 @@ function makeItem(overrides: Partial<ChecklistItem> = {}): ChecklistItem {
   };
 }
 
-describe('Mycelia evaluator - deduplication', () => {
-  let sentEmails: Array<{ to: string; subject: string; body: string }> = [];
-  let appendedEvents: Array<{ summary: string; metadata?: Record<string, unknown> }> = [];
+interface MyceliaRequestData {
+  id: string;
+  requester_id: string;
+  title: string;
+  request_type?: string;
+  status?: string;
+  response_count?: number;
+  max_responses?: number;
+  body?: string;
+  responses?: Array<{
+    id: string;
+    responder_id: string;
+    responder_name: string;
+    body: string;
+    confidence: number;
+    created_at: string;
+  }>;
+}
+
+function buildMyceliaRequest(overrides: Partial<MyceliaRequestData> = {}): MyceliaRequestData {
+  return {
+    id: 'req-1',
+    requester_id: 'other-agent',
+    title: 'Test request',
+    request_type: 'review',
+    status: 'open',
+    response_count: 0,
+    max_responses: 3,
+    created_at: new Date().toISOString(),
+    expires_at: new Date(Date.now() + 86400000).toISOString(),
+    ...overrides,
+  } as MyceliaRequestData;
+}
+
+function buildMyceliaResponse(overrides: Partial<{
+  id: string;
+  responder_id: string;
+  responder_name: string;
+  body: string;
+  confidence: number;
+}> = {}) {
+  return {
+    id: 'resp-1',
+    responder_id: 'helper-agent',
+    responder_name: 'Helper Bot',
+    body: 'Test response',
+    confidence: 8,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function createMockFetcher(
+  requests: MyceliaRequestData[],
+  agentTrustScore = 85,
+  requestDetails?: Record<string, MyceliaRequestData>
+): MyceliaApiFetcher {
+  return async (path, _configPath) => {
+    if (path === '/v1/requests') {
+      return {
+        ok: true,
+        data: { requests },
+      };
+    }
+    if (path === '/v1/agents/test-agent-id') {
+      return {
+        ok: true,
+        data: { agent: { trust_score: agentTrustScore, request_count: 5, response_count: 10 } },
+      };
+    }
+    if (requestDetails && path.startsWith('/v1/requests/')) {
+      const requestId = path.split('/').pop();
+      if (requestId && requestDetails[requestId]) {
+        return {
+          ok: true,
+          data: { request: requestDetails[requestId] },
+        };
+      }
+    }
+    return null;
+  };
+}
+
+interface TestSetup {
+  sentEmails: Array<{ to: string; subject: string; body: string }>;
+  appendedEvents: Array<{ summary: string; metadata?: Record<string, unknown> }>;
+  storedMetadata: Record<string, unknown>;
+  mockEmailSender: EmailSender;
+  mockBlackboard: MyceliaBlackboardAccessor;
+}
+
+function setupMyceliaTest(): TestSetup {
+  const sentEmails: Array<{ to: string; subject: string; body: string }> = [];
+  const appendedEvents: Array<{ summary: string; metadata?: Record<string, unknown> }> = [];
   let storedMetadata: Record<string, unknown> = {};
 
   const mockEmailSender: EmailSender = async (to, subject, body) => {
@@ -53,12 +148,36 @@ describe('Mycelia evaluator - deduplication', () => {
     },
   };
 
+  return { sentEmails, appendedEvents, storedMetadata, mockEmailSender, mockBlackboard };
+}
+
+function expectEmailSent(
+  emails: Array<{ to: string; subject: string; body: string }>,
+  subjectIncludes: string,
+  bodyIncludes?: string
+) {
+  expect(emails).toHaveLength(1);
+  expect(emails[0].subject).toContain(subjectIncludes);
+  if (bodyIncludes) {
+    expect(emails[0].body).toContain(bodyIncludes);
+  }
+}
+
+function expectNoEmail(emails: Array<{ to: string; subject: string; body: string }>) {
+  expect(emails).toHaveLength(0);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('Mycelia evaluator - deduplication', () => {
+  let setup: TestSetup;
+
   beforeEach(() => {
-    sentEmails = [];
-    appendedEvents = [];
-    storedMetadata = {};
-    setEmailSender(mockEmailSender);
-    setMyceliaBlackboardAccessor(mockBlackboard);
+    setup = setupMyceliaTest();
+    setEmailSender(setup.mockEmailSender);
+    setMyceliaBlackboardAccessor(setup.mockBlackboard);
   });
 
   afterEach(() => {
@@ -68,186 +187,67 @@ describe('Mycelia evaluator - deduplication', () => {
   });
 
   test('alerts on first run with claimable requests', async () => {
-    const mockFetcher: MyceliaApiFetcher = async (path, _configPath) => {
-      if (path === '/v1/requests') {
-        return {
-          ok: true,
-          data: {
-            requests: [
-              {
-                id: 'req-1',
-                requester_id: 'other-agent',
-                title: 'Help needed',
-                request_type: 'review',
-                status: 'open',
-                response_count: 0,
-                max_responses: 3,
-                created_at: new Date().toISOString(),
-                expires_at: new Date(Date.now() + 86400000).toISOString(),
-              },
-            ],
-          },
-        };
-      }
-      if (path === '/v1/agents/test-agent-id') {
-        return {
-          ok: true,
-          data: { agent: { trust_score: 85, request_count: 5, response_count: 10 } },
-        };
-      }
-      return null;
-    };
-
+    const mockFetcher = createMockFetcher([
+      buildMyceliaRequest({ id: 'req-1', title: 'Help needed' }),
+    ]);
     setMyceliaFetcher(mockFetcher);
 
     const result = await evaluateMycelia(makeItem());
 
     expect(result.status).toBe('alert');
     expect(result.summary).toContain('1 NEW request');
-    expect(sentEmails).toHaveLength(1);
-    expect(sentEmails[0].subject).toContain('[Mycelia] 1 NEW request available');
-    expect(sentEmails[0].body).toContain('Help needed');
-
-    // Verify metadata stored
-    expect(appendedEvents).toHaveLength(1);
-    expect(appendedEvents[0].metadata?.seenRequestIds).toEqual(['req-1']);
+    expectEmailSent(setup.sentEmails, '[Mycelia] 1 NEW request available', 'Help needed');
+    expect(setup.appendedEvents).toHaveLength(1);
+    expect(setup.appendedEvents[0].metadata?.seenRequestIds).toEqual(['req-1']);
   });
 
   test('does NOT alert on second run with same requests', async () => {
-    const mockFetcher: MyceliaApiFetcher = async (path, _configPath) => {
-      if (path === '/v1/requests') {
-        return {
-          ok: true,
-          data: {
-            requests: [
-              {
-                id: 'req-1',
-                requester_id: 'other-agent',
-                title: 'Help needed',
-                request_type: 'review',
-                status: 'open',
-                response_count: 0,
-                max_responses: 3,
-                created_at: new Date().toISOString(),
-                expires_at: new Date(Date.now() + 86400000).toISOString(),
-              },
-            ],
-          },
-        };
-      }
-      if (path === '/v1/agents/test-agent-id') {
-        return {
-          ok: true,
-          data: { agent: { trust_score: 85, request_count: 5, response_count: 10 } },
-        };
-      }
-      return null;
-    };
-
+    const mockFetcher = createMockFetcher([
+      buildMyceliaRequest({ id: 'req-1', title: 'Help needed' }),
+    ]);
     setMyceliaFetcher(mockFetcher);
 
     // First run
     await evaluateMycelia(makeItem());
-    sentEmails = [];
-    appendedEvents = [];
+    setup.sentEmails.length = 0;
+    setup.appendedEvents.length = 0;
 
     // Second run with same request
     const result = await evaluateMycelia(makeItem());
 
     expect(result.status).toBe('ok');
     expect(result.summary).toContain('no new activity');
-    expect(sentEmails).toHaveLength(0);
+    expectNoEmail(setup.sentEmails);
   });
 
   test('alerts only on NEW requests when some are already seen', async () => {
-    const mockFetcher: MyceliaApiFetcher = async (path, _configPath) => {
-      if (path === '/v1/requests') {
-        return {
-          ok: true,
-          data: {
-            requests: [
-              {
-                id: 'req-1',
-                requester_id: 'other-agent',
-                title: 'Old request',
-                request_type: 'review',
-                status: 'open',
-                response_count: 0,
-                max_responses: 3,
-                created_at: new Date().toISOString(),
-                expires_at: new Date(Date.now() + 86400000).toISOString(),
-              },
-              {
-                id: 'req-2',
-                requester_id: 'other-agent',
-                title: 'New request',
-                request_type: 'review',
-                status: 'open',
-                response_count: 0,
-                max_responses: 3,
-                created_at: new Date().toISOString(),
-                expires_at: new Date(Date.now() + 86400000).toISOString(),
-              },
-            ],
-          },
-        };
-      }
-      if (path === '/v1/agents/test-agent-id') {
-        return {
-          ok: true,
-          data: { agent: { trust_score: 85, request_count: 5, response_count: 10 } },
-        };
-      }
-      return null;
-    };
-
+    const mockFetcher = createMockFetcher([
+      buildMyceliaRequest({ id: 'req-1', title: 'Old request' }),
+      buildMyceliaRequest({ id: 'req-2', title: 'New request' }),
+    ]);
     setMyceliaFetcher(mockFetcher);
 
     // Seed with req-1 already seen
-    storedMetadata = {
-      seenRequestIds: ['req-1'],
-      responseCountsByRequestId: {},
-    };
+    setup.storedMetadata.seenRequestIds = ['req-1'];
+    setup.storedMetadata.responseCountsByRequestId = {};
 
     const result = await evaluateMycelia(makeItem());
 
     expect(result.status).toBe('alert');
     expect(result.summary).toContain('1 NEW request');
-    expect(sentEmails).toHaveLength(1);
-    expect(sentEmails[0].body).toContain('New request');
-    expect(sentEmails[0].body).not.toContain('Old request');
+    expect(setup.sentEmails).toHaveLength(1);
+    expect(setup.sentEmails[0].body).toContain('New request');
+    expect(setup.sentEmails[0].body).not.toContain('Old request');
   });
 });
 
 describe('Mycelia evaluator - response tracking', () => {
-  let sentEmails: Array<{ to: string; subject: string; body: string }> = [];
-  let appendedEvents: Array<{ summary: string; metadata?: Record<string, unknown> }> = [];
-  let storedMetadata: Record<string, unknown> = {};
-
-  const mockEmailSender: EmailSender = async (to, subject, body) => {
-    sentEmails.push({ to, subject, body });
-    return true;
-  };
-
-  const mockBlackboard: MyceliaBlackboardAccessor = {
-    findLastEventByCheckName: (_checkName: string) => {
-      if (Object.keys(storedMetadata).length === 0) return null;
-      return { metadata: JSON.stringify(storedMetadata) };
-    },
-    appendEvent: (opts) => {
-      appendedEvents.push(opts);
-      if (opts.metadata) {
-        storedMetadata = opts.metadata;
-      }
-    },
-  };
+  let setup: TestSetup;
 
   beforeEach(() => {
-    sentEmails = [];
-    appendedEvents = [];
-    storedMetadata = {};
-    setEmailSender(mockEmailSender);
-    setMyceliaBlackboardAccessor(mockBlackboard);
+    setup = setupMyceliaTest();
+    setEmailSender(setup.mockEmailSender);
+    setMyceliaBlackboardAccessor(setup.mockBlackboard);
   });
 
   afterEach(() => {
@@ -257,207 +257,77 @@ describe('Mycelia evaluator - response tracking', () => {
   });
 
   test('alerts when our request receives new responses', async () => {
-    const mockFetcher: MyceliaFetcher = async (path) => {
-      if (path === '/v1/requests/our-req-1') {
-        return {
-          ok: true,
-          data: {
-            request: {
-              id: 'our-req-1',
-              requester_id: 'test-agent-id',
-              title: 'Our request',
-              body: 'Please review this',
-              request_type: 'review',
-              status: 'open',
-              response_count: 1,
-              max_responses: 3,
-              created_at: new Date().toISOString(),
-              expires_at: new Date(Date.now() + 86400000).toISOString(),
-              responses: [
-                {
-                  id: 'resp-1',
-                  responder_id: 'helper-agent',
-                  responder_name: 'Helper Bot',
-                  body: 'This looks great! Just a few minor suggestions...',
-                  confidence: 8,
-                  created_at: new Date().toISOString(),
-                },
-              ],
-            },
-          },
-        };
+    const responseBody = 'This looks great! Just a few minor suggestions...';
+    const mockFetcher = createMockFetcher(
+      [buildMyceliaRequest({ id: 'our-req-1', requester_id: 'test-agent-id', title: 'Our request', response_count: 1 })],
+      85,
+      {
+        'our-req-1': buildMyceliaRequest({
+          id: 'our-req-1',
+          requester_id: 'test-agent-id',
+          title: 'Our request',
+          body: 'Please review this',
+          response_count: 1,
+          responses: [buildMyceliaResponse({ body: responseBody, confidence: 8 })],
+        }),
       }
-      if (path === '/v1/requests') {
-        return {
-          ok: true,
-          data: {
-            requests: [
-              {
-                id: 'our-req-1',
-                requester_id: 'test-agent-id',
-                title: 'Our request',
-                request_type: 'review',
-                status: 'open',
-                response_count: 1,
-                max_responses: 3,
-                created_at: new Date().toISOString(),
-                expires_at: new Date(Date.now() + 86400000).toISOString(),
-              },
-            ],
-          },
-        };
-      }
-      if (path === '/v1/agents/test-agent-id') {
-        return {
-          ok: true,
-          data: { agent: { trust_score: 85, request_count: 5, response_count: 10 } },
-        };
-      }
-      return null;
-    };
-
+    );
     setMyceliaFetcher(mockFetcher);
 
     // Seed with response_count = 0
-    storedMetadata = {
-      seenRequestIds: [],
-      responseCountsByRequestId: { 'our-req-1': 0 },
-    };
+    setup.storedMetadata.seenRequestIds = [];
+    setup.storedMetadata.responseCountsByRequestId = { 'our-req-1': 0 };
 
     const result = await evaluateMycelia(makeItem());
 
     expect(result.status).toBe('alert');
     expect(result.summary).toContain('1 new response');
-    expect(sentEmails).toHaveLength(1);
-    expect(sentEmails[0].subject).toContain('[Mycelia] 1 new response to: Our request');
-    expect(sentEmails[0].body).toContain('Helper Bot');
-    expect(sentEmails[0].body).toContain('Confidence: 8/10');
-    expect(sentEmails[0].body).toContain('This looks great! Just a few minor suggestions...');
+    expect(setup.sentEmails).toHaveLength(1);
+    expect(setup.sentEmails[0].subject).toContain('[Mycelia] 1 new response to: Our request');
+    expect(setup.sentEmails[0].body).toContain('Helper Bot');
+    expect(setup.sentEmails[0].body).toContain('Confidence: 8/10');
+    expect(setup.sentEmails[0].body).toContain(responseBody);
   });
 
   test('does NOT alert when response count unchanged', async () => {
-    const mockFetcher: MyceliaApiFetcher = async (path, _configPath) => {
-      if (path === '/v1/requests') {
-        return {
-          ok: true,
-          data: {
-            requests: [
-              {
-                id: 'our-req-1',
-                requester_id: 'test-agent-id',
-                title: 'Our request',
-                request_type: 'review',
-                status: 'open',
-                response_count: 1,
-                max_responses: 3,
-                created_at: new Date().toISOString(),
-                expires_at: new Date(Date.now() + 86400000).toISOString(),
-              },
-            ],
-          },
-        };
-      }
-      if (path === '/v1/agents/test-agent-id') {
-        return {
-          ok: true,
-          data: { agent: { trust_score: 85, request_count: 5, response_count: 10 } },
-        };
-      }
-      return null;
-    };
-
+    const mockFetcher = createMockFetcher([
+      buildMyceliaRequest({ id: 'our-req-1', requester_id: 'test-agent-id', title: 'Our request', response_count: 1 }),
+    ]);
     setMyceliaFetcher(mockFetcher);
 
     // Seed with response_count = 1 (same as current)
-    storedMetadata = {
-      seenRequestIds: [],
-      responseCountsByRequestId: { 'our-req-1': 1 },
-    };
+    setup.storedMetadata.seenRequestIds = [];
+    setup.storedMetadata.responseCountsByRequestId = { 'our-req-1': 1 };
 
     const result = await evaluateMycelia(makeItem());
 
     expect(result.status).toBe('ok');
-    expect(sentEmails).toHaveLength(0);
+    expectNoEmail(setup.sentEmails);
   });
 
   test('alerts with both new claimable requests AND new responses', async () => {
-    const mockFetcher: MyceliaFetcher = async (path) => {
-      if (path === '/v1/requests/our-req-1') {
-        return {
-          ok: true,
-          data: {
-            request: {
-              id: 'our-req-1',
-              requester_id: 'test-agent-id',
-              title: 'Our request',
-              body: 'Please review this',
-              request_type: 'review',
-              status: 'open',
-              response_count: 1,
-              max_responses: 3,
-              created_at: new Date().toISOString(),
-              expires_at: new Date(Date.now() + 86400000).toISOString(),
-              responses: [
-                {
-                  id: 'resp-1',
-                  responder_id: 'helper-agent',
-                  responder_name: 'Helper Bot',
-                  body: 'Looks good!',
-                  confidence: 9,
-                  created_at: new Date().toISOString(),
-                },
-              ],
-            },
-          },
-        };
+    const mockFetcher = createMockFetcher(
+      [
+        buildMyceliaRequest({ id: 'our-req-1', requester_id: 'test-agent-id', title: 'Our request', response_count: 1 }),
+        buildMyceliaRequest({ id: 'req-2', title: 'New claimable request' }),
+      ],
+      85,
+      {
+        'our-req-1': buildMyceliaRequest({
+          id: 'our-req-1',
+          requester_id: 'test-agent-id',
+          title: 'Our request',
+          body: 'Please review this',
+          response_count: 1,
+          responses: [buildMyceliaResponse({ body: 'Looks good!', confidence: 9 })],
+        }),
       }
-      if (path === '/v1/requests') {
-        return {
-          ok: true,
-          data: {
-            requests: [
-              {
-                id: 'our-req-1',
-                requester_id: 'test-agent-id',
-                title: 'Our request',
-                request_type: 'review',
-                status: 'open',
-                response_count: 1,
-                max_responses: 3,
-                created_at: new Date().toISOString(),
-                expires_at: new Date(Date.now() + 86400000).toISOString(),
-              },
-              {
-                id: 'req-2',
-                requester_id: 'other-agent',
-                title: 'New claimable request',
-                request_type: 'review',
-                status: 'open',
-                response_count: 0,
-                max_responses: 3,
-                created_at: new Date().toISOString(),
-                expires_at: new Date(Date.now() + 86400000).toISOString(),
-              },
-            ],
-          },
-        };
-      }
-      if (path === '/v1/agents/test-agent-id') {
-        return {
-          ok: true,
-          data: { agent: { trust_score: 85, request_count: 5, response_count: 10 } },
-        };
-      }
-      return null;
-    };
-
+    );
     setMyceliaFetcher(mockFetcher);
 
     // Seed with no previous data
-    storedMetadata = {
-      seenRequestIds: [],
-      responseCountsByRequestId: { 'our-req-1': 0 },
-    };
+    setup.storedMetadata.seenRequestIds = [];
+    setup.storedMetadata.responseCountsByRequestId = { 'our-req-1': 0 };
 
     const result = await evaluateMycelia(makeItem());
 
@@ -465,8 +335,8 @@ describe('Mycelia evaluator - response tracking', () => {
     expect(result.summary).toContain('1 NEW request');
 
     // Should send 2 emails: one for response, one for claimable
-    expect(sentEmails).toHaveLength(2);
-    expect(sentEmails.some(e => e.subject.includes('new response'))).toBe(true);
-    expect(sentEmails.some(e => e.subject.includes('NEW request'))).toBe(true);
+    expect(setup.sentEmails).toHaveLength(2);
+    expect(setup.sentEmails.some(e => e.subject.includes('new response'))).toBe(true);
+    expect(setup.sentEmails.some(e => e.subject.includes('NEW request'))).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes #57

Automated fix for: Issue #57: Mycelia evaluator: deduplicate alerts and include response content